### PR TITLE
logme.js performs unsafe Object iterations without checking hasOwnProperty

### DIFF
--- a/lib/logme.js
+++ b/lib/logme.js
@@ -29,6 +29,9 @@ function Logme(config) {
   };
   
   for (var key in config) {
+    if (!Object.prototype.hasOwnProperty.call(config, key)) {
+      continue;
+    }
     this.options[key] = config[key];
   }
   
@@ -98,6 +101,9 @@ Logme.prototype.levels = {
 Logme.prototype.message = function(level, str) {
   var message = this.templates[level];
   for (var token in this.tokens) {
+    if (!Object.prototype.hasOwnProperty.call(this.tokens, token)) {
+      continue;
+    }
     message = message.replace(':' + token, this.tokens[token]());
   }
   return message.replace(':message', str);


### PR DESCRIPTION
Even in node.js, it's possible that the Object prototype can be modified with additional properties.

When this happens it is causing logme to fail because logme isn't checking hasOwnProperty() to ensure whether or not the property belongs to the object.

This pull request adds the two checks needed in logme.js

I've run make test and tests pass.

This pull request is ready to be merged.
