### PR TITLE
Fix wrong log level labels

### DIFF
--- a/lib/themes/clean.js
+++ b/lib/themes/clean.js
@@ -1,6 +1,6 @@
 /**
  * Logme - Minimalistic logging.
- * 
+ *
  * Author: Veselin Todorov <hi@vesln.com>
  * Licensed under the MIT License.
  */
@@ -13,8 +13,8 @@ var color = require('cli-color');
 module.exports = {
   debug: '[:date] debug: :message' ,
   info: '[:date] info: :message',
-  warning: '[:date] info: :message',
-  error: '[:date] info: :message',
+  warning: '[:date] warning: :message',
+  error: '[:date] error: :message',
   critical: '[:date] critical: :message',
   inspect: false
 };

--- a/lib/themes/minimalistic.js
+++ b/lib/themes/minimalistic.js
@@ -1,6 +1,6 @@
 /**
  * Logme - Minimalistic logging.
- * 
+ *
  * Author: Veselin Todorov <hi@vesln.com>
  * Licensed under the MIT License.
  */
@@ -11,7 +11,7 @@
 module.exports = {
   debug: 'debug: :message' ,
   info: 'info: :message',
-  warning: 'info: :message',
-  error: 'info: :message',
+  warning: 'warning: :message',
+  error: 'error: :message',
   critical: 'critical: :message'
 };


### PR DESCRIPTION
Themes clean and minimalistic have wrong labels. I suggest this fix and a release of a bumped version at npm.
